### PR TITLE
Preserve block size when copying files with DistCp

### DIFF
--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
@@ -142,8 +142,9 @@ public class DistCpWrapper {
       if (useDistcpUpdate) {
         distcpArgs.add("-update");
       }
-      // Preserve user, group, permissions
-      distcpArgs.add("-pugp");
+      // Preserve user, group, permissions, and block size. Preserving block size is needed for
+      // DistCp to use built in checksums for verification.
+      distcpArgs.add("-pugpb");
       distcpArgs.add(srcDir.toString());
       distcpArgs.add(distcpDestDir.toString());
       LOG.debug("Running DistCp with args: " + distcpArgs);


### PR DESCRIPTION
When copying files, the block size should be preserved. Otherwise, files
with different block sizes can't be verified using the built-in checksums.