### PR TITLE
Add option to disable synchronizing file modified times after a copy

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/configuration/ObjectConflictHandler.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/configuration/ObjectConflictHandler.java
@@ -56,8 +56,8 @@ public class ObjectConflictHandler implements Configurable {
     HiveObjectSpec spec =
         new HiveObjectSpec(existingDestTable.getDbName(), existingDestTable.getTableName());
 
-    if (existingDestTable.getParameters().get(HiveParameterKeys.SRC_CLUSTER) != null &&
-        !existingDestTable.getParameters().get(HiveParameterKeys.SRC_CLUSTER)
+    if (existingDestTable.getParameters().get(HiveParameterKeys.SRC_CLUSTER) != null
+        && !existingDestTable.getParameters().get(HiveParameterKeys.SRC_CLUSTER)
         .equals(srcCluster.getName())) {
       LOG.warn("Table " + spec + " exists on destination, and it's "
           + "missing tags that indicate that it was replicated.");

--- a/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
@@ -66,6 +66,11 @@ public class ConfigurationKeys {
   public static final String COPY_JOB_TIMEOUT_SECONDS = "airbnb.reair.copy.timeout.seconds";
   // If a replication job fails, the number of times to retry the job.
   public static final String JOB_RETRIES = "airbnb.reair.job.retries";
+  // After a copy, whether to set / check that modified times for the copied files match between
+  // the source and the destination. Set to false for file systems that don't support changes
+  // to the modified time.
+  public static final String SYNC_MODIFIED_TIMES_FOR_FILE_COPY =
+      "airbnb.reair.copy.sync_modified_times";
 
   // Following are settings pertinent to batch replication only.
 

--- a/main/src/main/java/com/airbnb/reair/incremental/deploy/ReplicationLauncher.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/deploy/ReplicationLauncher.java
@@ -169,7 +169,9 @@ public class ReplicationLauncher {
         dbKeyValueStore,
         persistedJobInfoStore,
         filter,
-        new DirectoryCopier(conf, destCluster.getTmpDir(), true),
+        new DirectoryCopier(conf,
+            destCluster.getTmpDir(),
+            conf.getBoolean(ConfigurationKeys.SYNC_MODIFIED_TIMES_FOR_FILE_COPY, true)),
         numWorkers,
         maxJobsInMemory,
         startAfterAuditLogId);

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
@@ -168,7 +168,7 @@ public class DistCpWrapper {
       }
     }
 
-    if (!FsUtils.equalDirs(conf, srcDir, distcpDestDir)) {
+    if (!FsUtils.equalDirs(conf, srcDir, distcpDestDir, Optional.empty(), syncModificationTimes)) {
       LOG.error("Source and destination sizes don't match!");
       if (atomic) {
         LOG.debug("Since it's an atomic copy, deleting " + distcpDestDir);

--- a/utils/src/main/java/com/airbnb/reair/common/FsUtils.java
+++ b/utils/src/main/java/com/airbnb/reair/common/FsUtils.java
@@ -177,7 +177,8 @@ public class FsUtils {
    * @return a map from the path to a file relative to the root (e.g. a/b.txt) to the associated
    *         modification time
    */
-  private static Map<String, Long> getRelPathToModificationTime(Path root, Set<FileStatus> statuses)
+  private static Map<String, Long> getRelativePathToModificationTime(Path root,
+                                                                     Set<FileStatus> statuses)
       throws ArgumentException {
     Map<String, Long> pathToStatus = new HashMap<>();
     for (FileStatus status : statuses) {
@@ -195,6 +196,7 @@ public class FsUtils {
    *         the file was '/a/b/c.txt', the relative path would be 'b/c.txt'
    */
   public static String getRelativePath(Path root, Path child) {
+    // TODO: Use URI.relativize()
     String prefix = root.toString() + "/";
     if (!child.toString().startsWith(prefix)) {
       throw new RuntimeException("Invalid root: " + root + " and child " + child);
@@ -344,8 +346,8 @@ public class FsUtils {
       Map<String, Long> destFileModificationTimes = null;
 
       try {
-        srcFileModificationTimes = getRelPathToModificationTime(src, srcFileStatuses);
-        destFileModificationTimes = getRelPathToModificationTime(dest, destFileStatuses);
+        srcFileModificationTimes = getRelativePathToModificationTime(src, srcFileStatuses);
+        destFileModificationTimes = getRelativePathToModificationTime(dest, destFileStatuses);
       } catch (ArgumentException e) {
         throw new IOException("Invalid file statuses!", e);
       }
@@ -383,7 +385,7 @@ public class FsUtils {
     Map<String, Long> srcFileModificationTimes = null;
 
     try {
-      srcFileModificationTimes = getRelPathToModificationTime(src, srcFileStatuses);
+      srcFileModificationTimes = getRelativePathToModificationTime(src, srcFileStatuses);
     } catch (ArgumentException e) {
       throw new IOException("Invalid file statuses!", e);
     }


### PR DESCRIPTION
Some file systems do not support changing the modified time of a file, so this
configuration option allows the user to disable synchronizing modified
times after a file has been copied to the destination warehouse.