### PR TITLE
[thirft-api] Resolving issue with alter partition

### DIFF
--- a/hive-hooks/src/main/java/com/airbnb/reair/hive/hooks/MetastoreAuditLogListener.java
+++ b/hive-hooks/src/main/java/com/airbnb/reair/hive/hooks/MetastoreAuditLogListener.java
@@ -208,24 +208,24 @@ public class MetastoreAuditLogListener extends MetaStoreEventListener {
    * <p>For auditing purposes the read/write differential is the old and new
    * partition respectively.</p>
    *
-   * <p>Additionally the AlterPartitionEvent does not provide access to the
-   * underlying table associated with the partitions, hence it is necessary to
-   * create a minimal viable object in order to instantiate a metadata Partition
-   * object.</p>
-   * XXX
+   * <p>Note that a bug in the AlterPartitionEvent which has been resolved in
+   * a later version does not provide access to the underlying table associated
+   * with the partitions, hence it is necessary to fetch it from the metastore.
+   * </p>
+   *
    * @param event The add partition event
    */
   @Override
   public void onAlterPartition(AlterPartitionEvent event) throws MetaException {
     try {
 
-      // Table is invariant and thus arbitrary choice between old and new.
+      // Table is invariant and thus an arbitrary choice between old and new.
       Table table = new Table(
-          event.getOldPartition().getDbName(),
-          event.getOldPartition().getTableName()
+          event.getHandler().get_table(
+              event.getOldPartition().getDbName(),
+              event.getOldPartition().getTableName()
+          )
       );
-
-      table.setPartCols(event.getOldPartition().getSd().getCols());
 
       Set<ReadEntity> readEntities = new HashSet<>();
 

--- a/hive-hooks/src/test/java/com/airbnb/hive/MetastoreAuditLogListenerTest.java
+++ b/hive-hooks/src/test/java/com/airbnb/hive/MetastoreAuditLogListenerTest.java
@@ -18,6 +18,8 @@ import com.airbnb.reair.utils.ReplicationTestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.HiveMetaStore.HMSHandler;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -34,6 +36,7 @@ import org.apache.hadoop.hive.metastore.events.DropPartitionEvent;
 import org.apache.hadoop.hive.metastore.events.DropTableEvent;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -639,7 +642,7 @@ public class MetastoreAuditLogListenerTest {
     // Set up the source.
     StorageDescriptor sd = new StorageDescriptor();
     sd.setSerdeInfo(new SerDeInfo());
-    sd.setLocation("dummy/");
+    sd.setLocation("hdfs://dummy/");
 
     Table table = new Table();
     table.setDbName("test_db");
@@ -731,10 +734,10 @@ public class MetastoreAuditLogListenerTest {
       "TABLE",
       "{\"1\":{\"str\":\"test_table\"},\"2\":{\"str\":\"test_db\"},\"4\":{\"i32"
         + "\":0},\"5\":{\"i32\":0},\"6\":{\"i32\":0},\"7\":{\"rec\":{\"2\":{\"s"
-        + "tr\":\"dummy/\"},\"5\":{\"tf\":0},\"6\":{\"i32\":0},\"7\":{\"rec\":{"
-        + "}}}},\"8\":{\"lst\":[\"rec\",1,{\"1\":{\"str\":\"ds\"},\"2\":{\"str"
-        + "\":\"string\"},\"3\":{\"str\":\"UTC date\"}}]},\"12\":{\"str\":\"EXT"
-        + "ERNAL_TABLE\"}}"
+        + "tr\":\"hdfs://dummy/\"},\"5\":{\"tf\":0},\"6\":{\"i32\":0},\"7\":{\""
+        + "rec\":{}}}},\"8\":{\"lst\":[\"rec\",1,{\"1\":{\"str\":\"ds\"},\"2\":"
+        + "{\"str\":\"string\"},\"3\":{\"str\":\"UTC date\"}}]},\"12\":{\"str\""
+        + ":\"EXTERNAL_TABLE\"}}"
     );
 
     assertEquals(expectedDbRow, outputObjectsRow);
@@ -752,8 +755,8 @@ public class MetastoreAuditLogListenerTest {
         "PARTITION",
         "{\"1\":{\"lst\":[\"str\",1,\"2016-01-01\"]},\"2\":{\"str\":\"test_db\""
           + "},\"3\":{\"str\":\"test_table\"},\"4\":{\"i32\":0},\"5\":{\"i32\":"
-          + "0},\"6\":{\"rec\":{\"2\":{\"str\":\"dummy/ds=2016-01-01\"},\"5\":{"
-          + "\"tf\":0},\"6\":{\"i32\":0}}}}"
+          + "0},\"6\":{\"rec\":{\"2\":{\"str\":\"hdfs://dummy/ds=2016-01-01\"},"
+          + "\"5\":{\"tf\":0},\"6\":{\"i32\":0}}}}"
     );
 
     assertEquals(expectedDbRow, outputObjectsRow);
@@ -774,7 +777,7 @@ public class MetastoreAuditLogListenerTest {
     // Set up the source.
     StorageDescriptor sd = new StorageDescriptor();
     sd.setSerdeInfo(new SerDeInfo());
-    sd.setLocation("dummy/");
+    sd.setLocation("hdfs://dummy/");
 
     Table table = new Table();
     table.setDbName("test_db");
@@ -850,10 +853,10 @@ public class MetastoreAuditLogListenerTest {
         "TABLE",
         "{\"1\":{\"str\":\"test_table\"},\"2\":{\"str\":\"test_db\"},\"4\":{\"i"
           + "32\":0},\"5\":{\"i32\":0},\"6\":{\"i32\":0},\"7\":{\"rec\":{\"2\":"
-          + "{\"str\":\"dummy/\"},\"5\":{\"tf\":0},\"6\":{\"i32\":0},\"7\":{\"r"
-          + "ec\":{}}}},\"8\":{\"lst\":[\"rec\",1,{\"1\":{\"str\":\"ds\"},\"2\""
-          + ":{\"str\":\"string\"},\"3\":{\"str\":\"UTC date\"}}]},\"12\":{\"st"
-          + "r\":\"EXTERNAL_TABLE\"}}"
+          + "{\"str\":\"hdfs://dummy/\"},\"5\":{\"tf\":0},\"6\":{\"i32\":0},\"7"
+          + "\":{\"rec\":{}}}},\"8\":{\"lst\":[\"rec\",1,{\"1\":{\"str\":\"ds\""
+          + "},\"2\":{\"str\":\"string\"},\"3\":{\"str\":\"UTC date\"}}]},\"12"
+          + "\":{\"str\":\"EXTERNAL_TABLE\"}}"
     );
 
     assertEquals(expectedDbRow, inputObjectsRow);
@@ -871,8 +874,8 @@ public class MetastoreAuditLogListenerTest {
         "PARTITION",
         "{\"1\":{\"lst\":[\"str\",1,\"2016-01-01\"]},\"2\":{\"str\":\"test_db\""
           + "},\"3\":{\"str\":\"test_table\"},\"4\":{\"i32\":0},\"5\":{\"i32\":"
-          + "0},\"6\":{\"rec\":{\"2\":{\"str\":\"dummy/ds=2016-01-01\"},\"5\":{"
-          + "\"tf\":0},\"6\":{\"i32\":0}}}}"
+          + "0},\"6\":{\"rec\":{\"2\":{\"str\":\"hdfs://dummy/ds=2016-01-01\"},"
+          + "\"5\":{\"tf\":0},\"6\":{\"i32\":0}}}}"
     );
 
     assertEquals(expectedDbRow, inputObjectsRow);
@@ -909,11 +912,18 @@ public class MetastoreAuditLogListenerTest {
 
     // Set up the source.
     StorageDescriptor sd = new StorageDescriptor();
+    sd.setSerdeInfo(new SerDeInfo());
     sd.setLocation("hdfs://dummy");
+
+    Table table = new Table();
+    table.setDbName("test_db");
+    table.setTableName("test_table");
+    table.setTableType("EXTERNAL_TABLE");
+    table.setSd(sd);
 
     List<FieldSchema> partitionCols = new ArrayList<>();
     partitionCols.add(new FieldSchema("ds", "string", "UTC date"));
-    sd.setCols(partitionCols);
+    table.setPartitionKeys(partitionCols);
 
     Partition oldPartition = new Partition();
     oldPartition.setDbName("test_db");
@@ -933,11 +943,20 @@ public class MetastoreAuditLogListenerTest {
     newPartitionValues.add("2016-01-02");
     newPartition.setValues(newPartitionValues);
 
+    HMSHandler handler = Mockito.mock(HMSHandler.class);
+
+    Mockito.when(
+        handler.get_table(
+            Mockito.anyString(),
+            Mockito.anyString()
+        )
+    ).thenReturn(table);
+
     AlterPartitionEvent event = new AlterPartitionEvent(
         oldPartition,
         newPartition,
         false,
-        null
+        handler
     );
 
     metastoreAuditLogListener.onAlterPartition(event);
@@ -989,10 +1008,8 @@ public class MetastoreAuditLogListenerTest {
         "PARTITION",
         "{\"1\":{\"lst\":[\"str\",1,\"2016-01-01\"]},\"2\":{\"str\":\"test_db\""
           + "},\"3\":{\"str\":\"test_table\"},\"4\":{\"i32\":0},\"5\":{\"i32\":"
-          + "0},\"6\":{\"rec\":{\"1\":{\"lst\":[\"rec\",1,{\"1\":{\"str\":\"ds"
-          + "\"},\"2\":{\"str\":\"string\"},\"3\":{\"str\":\"UTC date\"}}]},\"2"
-          + "\":{\"str\":\"hdfs://dummy\"},\"5\":{\"tf\":0},\"6\":{\"i32\":0}}}"
-          + "}"
+          + "0},\"6\":{\"rec\":{\"2\":{\"str\":\"hdfs://dummy\"},\"5\":{\"tf\":"
+          + "0},\"6\":{\"i32\":0},\"7\":{\"rec\":{}}}}}"
     );
 
     assertEquals(expectedDbRow, inputObjectsRow);
@@ -1005,7 +1022,7 @@ public class MetastoreAuditLogListenerTest {
         "type",
         "serialized_object"
     );
-
+    
     List<String> outputObjectsRow = ReplicationTestUtils.getRow(
         dbConnectionFactory,
         DB_NAME,
@@ -1019,10 +1036,8 @@ public class MetastoreAuditLogListenerTest {
         "PARTITION",
         "{\"1\":{\"lst\":[\"str\",1,\"2016-01-02\"]},\"2\":{\"str\":\"test_db\""
           + "},\"3\":{\"str\":\"test_table\"},\"4\":{\"i32\":0},\"5\":{\"i32\":"
-          + "0},\"6\":{\"rec\":{\"1\":{\"lst\":[\"rec\",1,{\"1\":{\"str\":\"ds"
-          + "\"},\"2\":{\"str\":\"string\"},\"3\":{\"str\":\"UTC date\"}}]},\"2"
-          + "\":{\"str\":\"hdfs://dummy\"},\"5\":{\"tf\":0},\"6\":{\"i32\":0}}}"
-          + "}"
+          + "0},\"6\":{\"rec\":{\"2\":{\"str\":\"hdfs://dummy\"},\"5\":{\"tf\":"
+          + "0},\"6\":{\"i32\":0},\"7\":{\"rec\":{}}}}}"
     );
 
     assertEquals(expectedDbRow, outputObjectsRow);

--- a/hive-hooks/src/test/java/com/airbnb/hive/MetastoreAuditLogListenerTest.java
+++ b/hive-hooks/src/test/java/com/airbnb/hive/MetastoreAuditLogListenerTest.java
@@ -947,8 +947,8 @@ public class MetastoreAuditLogListenerTest {
 
     Mockito.when(
         handler.get_table(
-            Mockito.anyString(),
-            Mockito.anyString()
+            "test_db",
+            "test_table"
         )
     ).thenReturn(table);
 
@@ -1022,7 +1022,7 @@ public class MetastoreAuditLogListenerTest {
         "type",
         "serialized_object"
     );
-    
+
     List<String> outputObjectsRow = ReplicationTestUtils.getRow(
         dbConnectionFactory,
         DB_NAME,


### PR DESCRIPTION
This PR fixes an issue with the `onAlterPartition` event listener. The previous solution for defining a minimal viable table to work around the bug of the table not being associated with the event was not suffice. 

This issue has actually been fixed in newer versions of Hive, 

https://github.com/apache/hive/commit/71f8cd8430cc714106e3b0ff597a73320e27507c#diff-e5e61d7b4ede0525d16c819ae6d8f5c5L3128

however in the interim the solution was to mimic their logic and get an instance of the table from the metastore. Note mocking of this logic was required for testing purposes.

Also updated the dummy location for other test cases to be hdfs://dummy/

to: @plypaul 