### PR TITLE
[ci] disable artifact caching in CI due to gradle build flakiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_cache:
 
 cache:
   directories:
-    - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    - $HOME/.m2
 
 sudo: false


### PR DESCRIPTION
@plypaul

Disable gradle caching for now as it seems to be flaky (caching corrupt JARs like here: https://travis-ci.org/airbnb/reair/builds/130927574). It might be possible to fix the caching, but just disable it for now.

I have already cleared the existing caches.

Testing:
Cache size decreased significantly in travis after this change