### PR TITLE
Start after option should reset state

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/db/PersistedJobInfoStore.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/db/PersistedJobInfoStore.java
@@ -46,8 +46,11 @@ public class PersistedJobInfoStore {
 
   private static final Log LOG = LogFactory.getLog(PersistedJobInfoStore.class);
 
-  private static final String[] completedStateStrings = {ReplicationStatus.SUCCESSFUL.name(),
-      ReplicationStatus.FAILED.name(), ReplicationStatus.NOT_COMPLETABLE.name()};
+  private static final String[] completedStateStrings = {
+      ReplicationStatus.SUCCESSFUL.name(),
+      ReplicationStatus.FAILED.name(),
+      ReplicationStatus.NOT_COMPLETABLE.name(),
+      ReplicationStatus.ABORTED.name()};
 
   private DbConnectionFactory dbConnectionFactory;
   private String dbTableName;
@@ -133,8 +136,10 @@ public class PersistedJobInfoStore {
           }
         }));
     String query = String.format("SELECT id, create_time, operation, status, src_path, "
-        + "src_cluster, src_db, " + "src_table, src_partitions, src_tldt, "
-        + "rename_to_db, rename_to_table, rename_to_partition, " + "rename_to_path, extras "
+        + "src_cluster, src_db, "
+        + "src_table, src_partitions, src_tldt, "
+        + "rename_to_db, rename_to_table, rename_to_partition, "
+        + "rename_to_path, extras "
         + "FROM %s WHERE status NOT IN (%s) ORDER BY id", dbTableName, completedStateList);
 
     List<PersistedJobInfo> persistedJobInfos = new ArrayList<>();

--- a/main/src/main/java/com/airbnb/reair/incremental/deploy/ReplicationLauncher.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/deploy/ReplicationLauncher.java
@@ -238,9 +238,6 @@ public class ReplicationLauncher {
         .withArgName("ID")
         .create());
 
-    options.addOption(OptionBuilder.withLongOpt("reset-state")
-        .create());
-
     CommandLineParser parser = new BasicParser();
     CommandLine cl = parser.parse(options, argv);
 
@@ -257,17 +254,7 @@ public class ReplicationLauncher {
       startAfterId = Optional.of(
           Long.parseLong(cl.getOptionValue("start-after-id")));
       LOG.info("startAfterId="  + startAfterId);
-    }
-
-    if (cl.hasOption("reset-state")) {
       resetState = true;
-      LOG.info("resetState=" + resetState);
-    }
-
-    // Require specifying the start ID if resetting the state to make it easier to reason
-    if (resetState && startAfterId == null) {
-      throw new ConfigurationException("Start after ID must be specified when resetting "
-          + "state");
     }
 
     // Threads shouldn't exit with an exception - terminate to facilitate debugging.


### PR DESCRIPTION
Removing the `--reset-state` option and making the server reset state automatically when using the `--start-after-id` option.