### PR TITLE
Skip copying of the table for LOAD partition commands

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/ReplicationJobFactory.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/ReplicationJobFactory.java
@@ -561,8 +561,13 @@ public class ReplicationJobFactory {
     switch (operationType) {
       case COPY:
         // Handle the tables. The table is present in add partition
-        // calls, so skip in those cases.
-        if (auditLogEntry.getCommandType() != HiveOperation.ALTERTABLE_ADDPARTS) {
+        // calls, so skip in those cases. Also, for load commands, the table is mentioned as well
+        // in case of a partition load, so that can be omitted.
+        boolean shouldNotAddTables =
+            auditLogEntry.getCommandType() == HiveOperation.ALTERTABLE_ADDPARTS
+                || (auditLogEntry.getCommandType() == HiveOperation.LOAD
+                && auditLogEntry.getOutputPartitions().size() > 0);
+        if (!shouldNotAddTables) {
           for (Table t : outputTables) {
             replicationJobs.add(createJobForCopyTable(auditLogEntry.getId(),
                 auditLogEntry.getCreateTime().getTime(), t));


### PR DESCRIPTION
When using a `LOAD` command to load a partition, the outputs column in the audit log includes both the table and the partition. In such a case, the table should not need to be replicated.