### PR TITLE
Support replication of entries from the Thrift audit log

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/ReplicationJobFactory.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/ReplicationJobFactory.java
@@ -557,6 +557,16 @@ public class ReplicationJobFactory {
           operationType = OperationType.COPY;
         }
         break;
+      case THRIFT_ALTER_PARTITION:
+        NamedPartition inputPartition = auditLogEntry.getInputPartition();
+        List<NamedPartition> outputPartitions = auditLogEntry.getOutputPartitions();
+        if (inputPartition != null && outputPartitions.size() == 1
+            && !inputPartition.getName().equals(outputPartitions.get(0).getName())) {
+          operationType = OperationType.RENAME;
+        } else {
+          operationType = OperationType.COPY;
+        }
+        break;
       default:
         operationType = OperationType.COPY;
     }
@@ -616,10 +626,10 @@ public class ReplicationJobFactory {
           replicationJobs.add(createJobForRenameTable(auditLogEntry.getId(),
               auditLogEntry.getCreateTime().getTime(), auditLogEntry.getInputTable(),
               auditLogEntry.getOutputTables().get(0)));
-        } else if (auditLogEntry.getRenameFromPartition() != null) {
+        } else if (auditLogEntry.getInputPartition() != null) {
           // Handle a rename partition
           replicationJobs.add(createJobForRenamePartition(auditLogEntry.getId(),
-              auditLogEntry.getCreateTime().getTime(), auditLogEntry.getRenameFromPartition(),
+              auditLogEntry.getCreateTime().getTime(), auditLogEntry.getInputPartition(),
               auditLogEntry.getOutputPartitions().get(0)));
         } else {
           throw new RuntimeException("Shouldn't happen!");

--- a/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogEntry.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogEntry.java
@@ -23,7 +23,7 @@ public class AuditLogEntry {
   private List<Table> outputTables;
   private List<NamedPartition> outputPartitions;
   private Table inputTable;
-  private NamedPartition renameFromPartition;
+  private NamedPartition inputPartition;
 
   /**
    * Constructs AuditLogEntry using specific values.
@@ -38,7 +38,7 @@ public class AuditLogEntry {
    * @param outputTables tables that were changed
    * @param outputPartitions partitions that were changed
    * @param inputTable if renaming a table, the table that was renamed from
-   * @param renameFromPartition if renaming a partition, the partition that was renamed from.
+   * @param inputPartition if renaming a partition, the partition that was renamed from.
    */
   public AuditLogEntry(
       long id,
@@ -50,7 +50,7 @@ public class AuditLogEntry {
       List<Table> outputTables,
       List<NamedPartition> outputPartitions,
       Table inputTable,
-      NamedPartition renameFromPartition) {
+      NamedPartition inputPartition) {
     this.id = id;
     this.createTime = createTime;
     this.commandType = commandType;
@@ -60,7 +60,7 @@ public class AuditLogEntry {
     this.outputTables = outputTables;
     this.outputPartitions = outputPartitions;
     this.inputTable = inputTable;
-    this.renameFromPartition = renameFromPartition;
+    this.inputPartition = inputPartition;
   }
 
   public long getId() {
@@ -94,8 +94,8 @@ public class AuditLogEntry {
     return "AuditLogEntry{" + "id=" + id + ", createTime=" + createTime + ", commandType="
         + commandType + ", outputDirectories=" + outputDirectories + ", referenceTables="
         + referenceTableStrings + ", outputTables=" + outputTableStrings + ", outputPartitions="
-        + outputPartitionStrings + ", renameFromTable=" + inputTable + ", renameFromPartition="
-        + renameFromPartition + '}';
+        + outputPartitionStrings + ", renameFromTable=" + inputTable + ", inputPartition="
+        + inputPartition + '}';
   }
 
   public List<String> getOutputDirectories() {
@@ -118,8 +118,8 @@ public class AuditLogEntry {
     return inputTable;
   }
 
-  public NamedPartition getRenameFromPartition() {
-    return renameFromPartition;
+  public NamedPartition getInputPartition() {
+    return inputPartition;
   }
 
   public String getCommand() {

--- a/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogEntry.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogEntry.java
@@ -22,7 +22,7 @@ public class AuditLogEntry {
   private List<Table> referenceTables;
   private List<Table> outputTables;
   private List<NamedPartition> outputPartitions;
-  private Table renameFromTable;
+  private Table inputTable;
   private NamedPartition renameFromPartition;
 
   /**
@@ -37,7 +37,7 @@ public class AuditLogEntry {
    * @param referenceTables the partition's table if the outputs include partitions
    * @param outputTables tables that were changed
    * @param outputPartitions partitions that were changed
-   * @param renameFromTable if renaming a table, the table that was renamed from
+   * @param inputTable if renaming a table, the table that was renamed from
    * @param renameFromPartition if renaming a partition, the partition that was renamed from.
    */
   public AuditLogEntry(
@@ -49,7 +49,7 @@ public class AuditLogEntry {
       List<Table> referenceTables,
       List<Table> outputTables,
       List<NamedPartition> outputPartitions,
-      Table renameFromTable,
+      Table inputTable,
       NamedPartition renameFromPartition) {
     this.id = id;
     this.createTime = createTime;
@@ -59,7 +59,7 @@ public class AuditLogEntry {
     this.outputDirectories = outputDirectories;
     this.outputTables = outputTables;
     this.outputPartitions = outputPartitions;
-    this.renameFromTable = renameFromTable;
+    this.inputTable = inputTable;
     this.renameFromPartition = renameFromPartition;
   }
 
@@ -94,7 +94,7 @@ public class AuditLogEntry {
     return "AuditLogEntry{" + "id=" + id + ", createTime=" + createTime + ", commandType="
         + commandType + ", outputDirectories=" + outputDirectories + ", referenceTables="
         + referenceTableStrings + ", outputTables=" + outputTableStrings + ", outputPartitions="
-        + outputPartitionStrings + ", renameFromTable=" + renameFromTable + ", renameFromPartition="
+        + outputPartitionStrings + ", renameFromTable=" + inputTable + ", renameFromPartition="
         + renameFromPartition + '}';
   }
 
@@ -114,8 +114,8 @@ public class AuditLogEntry {
     return referenceTables;
   }
 
-  public Table getRenameFromTable() {
-    return renameFromTable;
+  public Table getInputTable() {
+    return inputTable;
   }
 
   public NamedPartition getRenameFromPartition() {

--- a/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogReader.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogReader.java
@@ -330,7 +330,7 @@ public class AuditLogReader {
 
         if ("OUTPUT".equals(objectCategory)) {
           outputPartitions.add(namedPartition);
-        } else if ("RENAME_FROM".equals(objectCategory)) {
+        } else if ("RENAME_FROM".equals(objectCategory) || "INPUT".equals(objectCategory)) {
           renameFromPartition = namedPartition;
         } else {
           throw new RuntimeException("Unhandled category: " + objectCategory);

--- a/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogReader.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogReader.java
@@ -251,7 +251,7 @@ public class AuditLogReader {
     List<Table> outputTables = new LinkedList<>();
     List<NamedPartition> outputPartitions = new LinkedList<>();
     List<Table> referenceTables = new LinkedList<>();
-    Table renameFromTable = null;
+    Table inputTable = null;
     NamedPartition renameFromPartition = null;
 
     while (rs.next()) {
@@ -282,7 +282,7 @@ public class AuditLogReader {
             referenceTables,
             outputTables,
             outputPartitions,
-            renameFromTable,
+            inputTable,
             renameFromPartition);
         auditLogEntries.add(entry);
         // Reset these accumulated values
@@ -291,7 +291,7 @@ public class AuditLogReader {
         outputTables = new LinkedList<>();
         outputPartitions = new LinkedList<>();
         renameFromPartition = null;
-        renameFromTable = null;
+        inputTable = null;
       }
 
       previouslyReadId = id;
@@ -312,8 +312,8 @@ public class AuditLogReader {
           outputTables.add(table);
         } else if ("REFERENCE_TABLE".equals(objectCategory)) {
           referenceTables.add(table);
-        } else if ("RENAME_FROM".equals(objectCategory)) {
-          renameFromTable = table;
+        } else if ("RENAME_FROM".equals(objectCategory) || "INPUT".equals(objectCategory)) {
+          inputTable = table;
         } else {
           throw new RuntimeException("Unhandled category: " + objectCategory);
         }
@@ -363,7 +363,7 @@ public class AuditLogReader {
           referenceTables,
           outputTables,
           outputPartitions,
-          renameFromTable,
+          inputTable,
           renameFromPartition);
       auditLogEntries.add(entry);
     }


### PR DESCRIPTION
`THRIFT_DROP_TABLE`, `THRIFT_DROP_PARTITION` and etc

One tricky difference is that the `category` field in the audit object log for table rename operation is `INPUT`, while in audit log, it's `RENAME_TO`. They are consolidated into the input table field.

`mvn test package` passed

@plypaul 