### PR TITLE
Use exchange partition enum value in HiveOperation

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/ReplicationJobFactory.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/ReplicationJobFactory.java
@@ -487,7 +487,8 @@ public class ReplicationJobFactory {
     // broken as per HIVE-12865. This workaround is to parse the exchange
     // partition command to figure out what the input and output partitions
     // are.
-    if (auditLogEntry.getOutputTables().size() == 0 && auditLogEntry.getCommandType() == null) {
+    if (auditLogEntry.getOutputTables().size() == 0
+        && auditLogEntry.getCommandType() == HiveOperation.ALTERTABLE_EXCHANGEPARTITION) {
       // This is probably an exchange partition command
       ExchangePartitionParser parser = new ExchangePartitionParser();
       boolean parsed = parser.parse(auditLogEntry.getCommand());

--- a/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogReader.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/auditlog/AuditLogReader.java
@@ -141,10 +141,6 @@ public class AuditLogReader {
       return null;
     }
 
-    if ("ALTERTABLE_EXCHANGEPARTITION".equals(operation)) {
-      return null;
-    }
-
     try {
       return HiveOperation.valueOf(operation);
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Previously, null was used as the exchange partition operation was not specified
in the HiveOperation enum.