### PR TITLE
Add ConfigurationKeys.SYNC_MODIFIED_TIMES_FOR_FILE_COPY to list of co…

### DIFF
--- a/main/src/main/java/com/airbnb/reair/batch/hive/MetastoreReplicationJob.java
+++ b/main/src/main/java/com/airbnb/reair/batch/hive/MetastoreReplicationJob.java
@@ -323,6 +323,7 @@ public class MetastoreReplicationJob extends Configured implements Tool {
         ConfigurationKeys.BATCH_JOB_INPUT_LIST,
         ConfigurationKeys.BATCH_JOB_METASTORE_PARALLELISM,
         ConfigurationKeys.BATCH_JOB_COPY_PARALLELISM,
+        ConfigurationKeys.SYNC_MODIFIED_TIMES_FOR_FILE_COPY,
         MRJobConfig.MAP_SPECULATIVE,
         MRJobConfig.REDUCE_SPECULATIVE
         );


### PR DESCRIPTION
SYNC_MODIFIED_TIMES_FOR_FILE_COPY needs to be in the merged configuration otherwise the setting is ignored for batch mode replication.