### PR TITLE
replace cp  to put

### DIFF
--- a/main/src/main/java/com/airbnb/reair/batch/hive/MetastoreReplicationJob.java
+++ b/main/src/main/java/com/airbnb/reair/batch/hive/MetastoreReplicationJob.java
@@ -602,11 +602,11 @@ public class MetastoreReplicationJob extends Configured implements Tool {
    * @throws IOException if there is an error copying the file.
    */
   private static void copyFile(Path srcFile, Path destFile) throws IOException {
-    String[] copyArgs = {"-cp", srcFile.toString(), destFile.toString()};
+    String[] copyArgs = {"-put", srcFile.toString(), destFile.toString()};
 
     FsShell shell = new FsShell();
     try {
-      LOG.debug("Using shell to copy with args " + Arrays.asList(copyArgs));
+      LOG.debug("Using shell to put with args " + Arrays.asList(copyArgs));
       ToolRunner.run(shell, copyArgs);
     } catch (Exception e) {
       throw new IOException(e);


### PR DESCRIPTION
i think the file on local is better,user cant put it on hdfs by youself  ,so i replace cp to put, and it pass test!
cmd:hadoop jar airbnb-reair-main-1.0.0-all.jar com.airbnb.reair.batch.hive.MetastoreReplicationJob --config-files config.xml --table-list table.txt

log info :
16/09/26 10:23:25 INFO hive.MetastoreReplicationJob: configPaths=config.xml
16/09/26 10:23:26 INFO security.UserGroupInformation: Login successful for user hadoop/reair using keytab file /home/hadoop/reair3.keytab
16/09/26 10:23:27 INFO hive.MetastoreReplicationJob: Registering hdfs://2testpajkcluster/tmp/dest/hive_replication/reair_1474856606268_2ed98052-aacc-4f47-8a17-f2a2be37ef0a to be deleted on exit
16/09/26 10:23:27 INFO hive.MetastoreReplicationJob: Copying table.txt to temporary directory hdfs://2testpajkcluster/tmp/dest/hive_replication/reair_1474856606268_2ed98052-aacc-4f47-8a17-f2a2be37ef0a/table.txt
Using shell to put with args [-put, table.txt, hdfs://2testpajkcluster/tmp/dest/hive_replication/reair_1474856606268_2ed98052-aacc-4f47-8a17-f2a2be37ef0a/table.txt]
16/09/26 10:23:27 INFO hive.MetastoreReplicationJob: Using shell to put with args [-put, table.txt, hdfs://2testpajkcluster/tmp/dest/hive_replication/reair_1474856606268_2ed98052-aacc-4f47-8a17-f2a2be37ef0a/table.txt]
16/09/26 10:23:28 INFO hive.MetastoreReplicationJob: Copied table.txt to temporary directory hdfs://2testpajkcluster/tmp/dest/hive_replication/reair_1474856606268_2ed98052-aacc-4f47-8a17-f2a2be37ef0a/table.txt
16/09/26 10:23:28 INFO hive.MetastoreReplicationJob: Deleting hdfs://2testpajkcluster/user/test/test_output/step1output
16/09/26 10:23:28 INFO common.FsUtils: get file by path :hdfs://2testpajkcluster/user/test/test_output/step1output
16/09/26 10:23:28 INFO common.FsUtils: user name :hadoop/reair@hadoop.com
16/09/26 10:23:28 INFO fs.TrashPolicyDefault: Namenode trash configuration: Deletion interval = 1440 minutes, Emptier interval = 0 minutes.
16/09/26 10:23:28 INFO hive.MetastoreReplicationJob: Deleting hdfs://2testpajkcluster/user/test/test_output/step2output
16/09/26 10:23:28 INFO common.FsUtils: get file by path :hdfs://2testpajkcluster/user/test/test_output/step2output
16/09/26 10:23:28 INFO common.FsUtils: user name :hadoop/reair@hadoop.com
16/09/26 10:23:28 INFO fs.TrashPolicyDefault: Namenode trash configuration: Deletion interval = 1440 minutes, Emptier interval = 0 minutes.
16/09/26 10:23:28 INFO hive.MetastoreReplicationJob: Deleting hdfs://2testpajkcluster/user/test/test_output/step3output
16/09/26 10:23:28 INFO common.FsUtils: get file by path :hdfs://2testpajkcluster/user/test/test_output/step3output
16/09/26 10:23:28 INFO common.FsUtils: user name :hadoop/reair@hadoop.com
16/09/26 10:23:28 INFO fs.TrashPolicyDefault: Namenode trash configuration: Deletion interval = 1440 minutes, Emptier interval = 0 minutes.
16/09/26 10:23:28 INFO hive.MetastoreReplicationJob: Starting job for step 1...
16/09/26 10:23:28 INFO client.RMProxy: Connecting to ResourceManager at a1-perf-hadoop-master01.hz/10.128.9.131:8032
16/09/26 10:23:28 INFO hdfs.DFSClient: Created HDFS_DELEGATION_TOKEN token 120 for hadoop on ha-hdfs:2testpajkcluster
16/09/26 10:23:28 INFO security.TokenCache: Got dt for hdfs://2testpajkcluster; Kind: HDFS_DELEGATION_TOKEN, Service: ha-hdfs:2testpajkcluster, Ident: (HDFS_DELEGATION_TOKEN token 120 for hadoop)
16/09/26 10:23:29 WARN mapreduce.JobSubmitter: Hadoop command-line option parsing not performed. Implement the Tool interface and execute your application with ToolRunner to remedy this.
16/09/26 10:23:29 INFO input.FileInputFormat: Total input paths to process : 1
16/09/26 10:23:29 INFO mapreduce.JobSubmitter: number of splits:1
16/09/26 10:23:29 INFO mapreduce.JobSubmitter: Submitting tokens for job: job_1474854960843_0010
16/09/26 10:23:29 INFO mapreduce.JobSubmitter: Kind: HDFS_DELEGATION_TOKEN, Service: ha-hdfs:2testpajkcluster, Ident: (HDFS_DELEGATION_TOKEN token 120 for hadoop)
16/09/26 10:23:30 INFO impl.YarnClientImpl: Submitted application application_1474854960843_0010
16/09/26 10:23:30 INFO mapreduce.Job: The url to track the job: http://a1-perf-hadoop-master01.hz:8088/proxy/application_1474854960843_0010/
16/09/26 10:23:30 INFO mapreduce.Job: Running job: job_1474854960843_0010
16/09/26 10:23:36 INFO mapreduce.Job: Job job_1474854960843_0010 running in uber mode : false
16/09/26 10:23:36 INFO mapreduce.Job:  map 0% reduce 0%
16/09/26 10:23:40 INFO mapreduce.Job:  map 100% reduce 0%
16/09/26 10:23:46 INFO mapreduce.Job:  map 100% reduce 60%
16/09/26 10:23:51 INFO mapreduce.Job:  map 100% reduce 100%
16/09/26 10:23:52 INFO mapreduce.Job: Job job_1474854960843_0010 completed successfully
16/09/26 10:23:52 INFO mapreduce.Job: Counters: 49
    File System Counters
        FILE: Number of bytes read=362
        FILE: Number of bytes written=587299
        FILE: Number of read operations=0
        FILE: Number of large read operations=0
        FILE: Number of write operations=0
        HDFS: Number of bytes read=215
        HDFS: Number of bytes written=221
        HDFS: Number of read operations=20
        HDFS: Number of large read operations=0
        HDFS: Number of write operations=10
    Job Counters 
        Launched map tasks=1
        Launched reduce tasks=5
        Data-local map tasks=1
        Total time spent by all maps in occupied slots (ms)=3018
        Total time spent by all reduces in occupied slots (ms)=47236
        Total time spent by all map tasks (ms)=3018
        Total time spent by all reduce tasks (ms)=23618
        Total vcore-seconds taken by all map tasks=3018
        Total vcore-seconds taken by all reduce tasks=23618
        Total megabyte-seconds taken by all map tasks=3090432
        Total megabyte-seconds taken by all reduce tasks=48369664
    Map-Reduce Framework
        Map input records=1
        Map output records=1
        Map output bytes=234
        Map output materialized bytes=262
        Input split bytes=181
        Combine input records=0
        Combine output records=0
        Reduce input groups=1
        Reduce shuffle bytes=262
        Reduce input records=1
        Reduce output records=1
        Spilled Records=2
        Shuffled Maps =5
        Failed Shuffles=0
        Merged Map outputs=5
        GC time elapsed (ms)=442
        CPU time spent (ms)=7350
        Physical memory (bytes) snapshot=1750175744
        Virtual memory (bytes) snapshot=17849155584
        Total committed heap usage (bytes)=3309305856
    Shuffle Errors
        BAD_ID=0
        CONNECTION=0
        IO_ERROR=0
        WRONG_LENGTH=0
        WRONG_MAP=0
        WRONG_REDUCE=0
    File Input Format Counters 
        Bytes Read=34
    File Output Format Counters 
        Bytes Written=221
16/09/26 10:23:52 INFO hive.MetastoreReplicationJob: Job for step 1 finished successfully! To view logging data, run the following commands in Hive: 

CREATE TABLE IF NOT EXISTS replication_step1_output (
      action_name STRING,         -- action for the entity
      src_path STRING,       -- source entity path
      dest_path STRING,      -- destination enitity path
      copy_data STRING,      -- should copy data
      copy_metadata STRING,  -- should copy metadata
      db_name STRING,        -- database name
      table_name STRING,     -- table name
      partition_name STRING) -- partition spec
PARTITIONED BY (
      job_start_time STRING)          -- job run timestamp
ROW FORMAT DELIMITED
  FIELDS TERMINATED BY '\t'
STORED AS TEXTFILE;

LOAD DATA INPATH 'hdfs://2testpajkcluster/user/test/test_output/step1output' OVERWRITE INTO TABLE replication_step1_output
PARTITION (job_start_time = '2016-09-26T02_23_26');
