### PR TITLE
Add option to disable checksum checks

### DIFF
--- a/main/src/main/java/com/airbnb/reair/batch/BatchUtils.java
+++ b/main/src/main/java/com/airbnb/reair/batch/BatchUtils.java
@@ -1,6 +1,7 @@
 package com.airbnb.reair.batch;
 
 import com.airbnb.reair.common.FsUtils;
+import com.airbnb.reair.incremental.deploy.ConfigurationKeys;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -95,16 +96,16 @@ public class BatchUtils {
 
         // If checksums exist and don't match, re-do the copy. If checksums do not exist, assume
         // that they match.
-        if (!FsUtils.checksumsMatch(conf, srcPath, tmpDstPath)
+        if (conf.getBoolean(ConfigurationKeys.BATCH_JOB_VERIFY_COPY_CHECKSUM, true)
+            && !FsUtils.checksumsMatch(conf, srcPath, tmpDstPath)
             .map(Boolean::booleanValue)
             .orElse(true)) {
-          LOG.warn(String.format("Not renaming %s to %s since checksums do not match between "
-                  + "%s and %s",
+          throw new IOException(String.format("Not renaming %s to %s since checksums do not match "
+                  + "between %s and %s",
               tmpDstPath,
               dstPath,
               srcPath,
               tmpDstPath));
-          continue;
         }
 
         dstFs.rename(tmpDstPath, dstPath);

--- a/main/src/main/java/com/airbnb/reair/batch/hive/MetastoreReplicationJob.java
+++ b/main/src/main/java/com/airbnb/reair/batch/hive/MetastoreReplicationJob.java
@@ -324,6 +324,7 @@ public class MetastoreReplicationJob extends Configured implements Tool {
         ConfigurationKeys.BATCH_JOB_METASTORE_PARALLELISM,
         ConfigurationKeys.BATCH_JOB_COPY_PARALLELISM,
         ConfigurationKeys.SYNC_MODIFIED_TIMES_FOR_FILE_COPY,
+        ConfigurationKeys.BATCH_JOB_VERIFY_COPY_CHECKSUM,
         MRJobConfig.MAP_SPECULATIVE,
         MRJobConfig.REDUCE_SPECULATIVE
         );

--- a/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
@@ -90,4 +90,7 @@ public class ConfigurationKeys {
   // The number of reducers to use for jobs where reducers perform file copies
   public static final String BATCH_JOB_COPY_PARALLELISM =
       "airbnb.reair.batch.copy.parallelism";
+  // Whether to try to compare checksums to validate file copies when possible
+  public static final String BATCH_JOB_VERIFY_COPY_CHECKSUM =
+      "airbnb.reair.batch.copy.checksum.verify";
 }


### PR DESCRIPTION
For copying from different filesystems, it may be the case that the checksum algorithms are different so it's not valid to compare them.