### PR TITLE
Adding Hive2.x support

### DIFF
--- a/hive-hooks/src/main/java/com/airbnb/reair/hive/hooks/SessionStateLite.java
+++ b/hive-hooks/src/main/java/com/airbnb/reair/hive/hooks/SessionStateLite.java
@@ -2,6 +2,7 @@ package com.airbnb.reair.hive.hooks;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.MapRedStats;
+import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
 import java.util.HashMap;
@@ -44,13 +45,16 @@ class SessionStateLite {
   /**
    * Creates a lightweight representation of the session state.
    *
-   * @param sessionState The Hive session state
+   * @param plan The Hive query plan
    */
-  public SessionStateLite(SessionState sessionState) {
-    this.cmd = sessionState.getCmd();
-    this.commandType = sessionState.getCommandType();
-    this.queryId = sessionState.getQueryId();
+  public SessionStateLite(QueryPlan plan) {
+
+    SessionState sessionState = SessionState.get();
+
     this.conf = new HiveConf(sessionState.getConf());
+    this.cmd = plan.getQueryStr();
+    this.commandType = plan.getOperationName();
+    this.queryId = plan.getQueryId();
     this.mapRedStats = new HashMap<>(sessionState.getMapRedStats());
   }
 

--- a/hive-hooks/src/test/java/com/airbnb/hive/CliAuditLogHookTest.java
+++ b/hive-hooks/src/test/java/com/airbnb/hive/CliAuditLogHookTest.java
@@ -105,6 +105,7 @@ public class CliAuditLogHookTest {
             "test_db",
             "test_output_table");
     outputTable.setCreateTime(0);
+    outputTable.setOwner("table.owner");
 
     List<org.apache.hadoop.hive.ql.metadata.Table> outputTables =
         new ArrayList<>();
@@ -167,8 +168,9 @@ public class CliAuditLogHookTest {
         "test_db.test_output_table",
         "TABLE",
         "{\"1\":{\"str\":\"test_"
-          + "output_table\"},\"2\":{\"str\":\"test_db\"},\"4\":"
-          + "{\"i32\":0},\"5\":{\"i32\":0},\"6\":{\"i3"
+          + "output_table\"},\"2\":{\"str\":\"test_db\"},"
+          + "\"3\":{\"str\":\"table.owner\"},"
+          + "\"4\":{\"i32\":0},\"5\":{\"i32\":0},\"6\":{\"i3"
           + "2\":0},\"7\":{\"rec\":{\"1\":{\"lst\":[\"rec\",0]}"
           + ",\"3\":{\"str\":\"org.apache.hadoop.mapred.Sequenc"
           + "eFileInputFormat\"},\"4\":{\"str\":\"org.apache.ha"


### PR DESCRIPTION
Hive 2.x discards the SessionState in the PostExecute interface so in order to get Hive operation type we need to get it directly from the QueryPlan which is available via HookContext in the ExecuteWithHookContext interface. Hive handles both hooks much like the same so the CliAuditLogHook should work fine for both Hive1.x and Hive2.x. In case of any issues separate hook for Hive2.x might be created. We have tested it with Hive2.x.