### PR TITLE
In Batch Copy, keep the same block size so that checksum is always th…

### DIFF
--- a/main/src/main/java/com/airbnb/reair/batch/BatchUtils.java
+++ b/main/src/main/java/com/airbnb/reair/batch/BatchUtils.java
@@ -86,7 +86,16 @@ public class BatchUtils {
           dstFs.delete(tmpDstPath, false);
         }
 
-        FSDataOutputStream outputStream = dstFs.create(tmpDstPath, progressable);
+        // Keep the same replication factor and block size as the source file.
+        FSDataOutputStream outputStream = dstFs.create(
+            tmpDstPath,
+            srcStatus.getPermission(),
+            true,
+            conf.getInt("io.file.buffer.size", 4096),
+            srcStatus.getReplication(),
+            srcStatus.getBlockSize(),
+            progressable);
+
         IOUtils.copyBytes(inputStream, outputStream, conf);
         inputStream.close();
         outputStream.close();


### PR DESCRIPTION
…e same format.