### PR TITLE
Log4j: add output logger name.

### DIFF
--- a/main/src/main/resources/log4j.properties
+++ b/main/src/main/resources/log4j.properties
@@ -5,7 +5,7 @@ log4j.rootLogger=INFO, Console, RollingAppender
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} [%t] %p - %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} [%t] %p %c - %m%n
 log4j.appender.Console.Threshold=INFO
 
 # Enable debug logging for this project
@@ -16,5 +16,5 @@ log4j.appender.RollingAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.RollingAppender.File=logs/reair.debug.log
 log4j.appender.RollingAppender.DatePattern='.'yyyy-MM-dd
 log4j.appender.RollingAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.RollingAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} [%t] %p - %m%n
+log4j.appender.RollingAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} [%t] %p %c - %m%n
 log4j.appender.RollingAppender.Threshold=DEBUG


### PR DESCRIPTION
Small change to make log more useful.

See https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html for what %c does.
