### PR TITLE
Fix the extra "/" bug in srcPath in DestinationObjectFactory

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/configuration/DestinationObjectFactory.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/configuration/DestinationObjectFactory.java
@@ -4,6 +4,8 @@ import com.airbnb.reair.common.FsUtils;
 import com.airbnb.reair.common.HiveParameterKeys;
 import com.airbnb.reair.incremental.ReplicationUtils;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -21,6 +23,8 @@ import java.util.Optional;
  * @version
  */
 public class DestinationObjectFactory implements Configurable {
+
+  private static final Log LOG = LogFactory.getLog(DestinationObjectFactory.class);
 
   private Optional<Configuration> conf;
 
@@ -59,10 +63,13 @@ public class DestinationObjectFactory implements Configurable {
     // If the source path is within the FS root of the source cluster,
     // it should have the same relative path on the destination
     Path destPath;
-    if (srcPath.toString().startsWith(srcCluster.getFsRoot().toString() + "/")) {
+    String srcFsRootWithSlash = FsUtils.getPathWithSlash(srcCluster.getFsRoot().toString());
+    if (srcPath.toString().startsWith(srcFsRootWithSlash)) {
       String relativePath = FsUtils.getRelativePath(srcCluster.getFsRoot(), srcPath);
       destPath = new Path(destCluster.getFsRoot(), relativePath);
     } else {
+      LOG.warn("srcPath " + srcPath.toString() + " doesn't start with "
+          + srcFsRootWithSlash);
       destPath = new Path(destCluster.getFsRoot(), srcPath.toUri().getPath());
     }
 

--- a/utils/src/main/java/com/airbnb/reair/common/FsUtils.java
+++ b/utils/src/main/java/com/airbnb/reair/common/FsUtils.java
@@ -188,6 +188,19 @@ public class FsUtils {
   }
 
   /**
+   * Add "/" to path if path doesn't end with "/".
+   */
+  public static String getPathWithSlash(String path) {
+    if (path == null) {
+      return null;
+    }
+    if (!path.endsWith("/")) {
+      path = path + "/";
+    }
+    return path;
+  }
+
+  /**
    * Get the path relative to another path.
    *
    * @param root the reference path
@@ -197,7 +210,7 @@ public class FsUtils {
    */
   public static String getRelativePath(Path root, Path child) {
     // TODO: Use URI.relativize()
-    String prefix = root.toString() + "/";
+    String prefix = getPathWithSlash(root.toString());
     if (!child.toString().startsWith(prefix)) {
       throw new RuntimeException("Invalid root: " + root + " and child " + child);
     }


### PR DESCRIPTION
The old code sometimes creates double slash unintentionally.

This patch adds a warning and also fixes the double slash situation.
