### PR TITLE
Ensure replication factor

### DIFF
--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
@@ -155,8 +155,8 @@ public class DistCpWrapper {
       if (useDistcpUpdate) {
         distcpArgs.add("-update");
       }
-      // Preserve user, group, permissions, and block size. Preserving block size is needed for
-      // DistCp to use built in checksums for verification.
+      // Preserve replication number, user, group, permissions, and block size. 
+      // Preserving block size is needed for DistCp to use built in checksums for verification.
       distcpArgs.add("-prugpb");
       distcpArgs.add(srcDir.toString());
       distcpArgs.add(distcpDestDir.toString());

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
@@ -157,7 +157,7 @@ public class DistCpWrapper {
       }
       // Preserve user, group, permissions, and block size. Preserving block size is needed for
       // DistCp to use built in checksums for verification.
-      distcpArgs.add("-pugpb");
+      distcpArgs.add("-prugpb");
       distcpArgs.add(srcDir.toString());
       distcpArgs.add(distcpDestDir.toString());
       LOG.debug("Running DistCp with args: " + distcpArgs);


### PR DESCRIPTION
I'm seeing the difference of replication factor between source and target Hadoop clusters. I'm not so sure you guys intend to ignore replication factor in the discp, but I feel like that's a bug.