### PR TITLE
Change dynamic timeout method

### DIFF
--- a/main/src/main/java/com/airbnb/reair/incremental/DirectoryCopier.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/DirectoryCopier.java
@@ -97,23 +97,23 @@ public class DirectoryCopier {
             ConfigurationKeys.COPY_JOB_DYNAMIC_TIMEOUT_ENABLED,
             ConfigurationKeys.COPY_JOB_TIMEOUT_SECONDS));
       }
-      long dynamicTimeoutSecPerGb = conf.getLong(
-          ConfigurationKeys.COPY_JOB_DYNAMIC_TIMEOUT_SEC_PER_GB,
+      long dynamicTimeoutMsPerGbPerMapper = conf.getLong(
+          ConfigurationKeys.COPY_JOB_DYNAMIC_TIMEOUT_MS_PER_GB_PER_MAPPER,
           -1);
-      if (dynamicTimeoutSecPerGb > 0) {
-        options.setDistcpDynamicJobTimeoutMsPerGb(1_000L * dynamicTimeoutSecPerGb);
+      if (dynamicTimeoutMsPerGbPerMapper > 0) {
+        options.setDistcpDynamicJobTimeoutMsPerGbPerMapper(dynamicTimeoutMsPerGbPerMapper);
       }
       long dynamicTimeoutMin = conf.getLong(
-          ConfigurationKeys.COPY_JOB_DYNAMIC_TIMEOUT_MIN,
+          ConfigurationKeys.COPY_JOB_DYNAMIC_TIMEOUT_BASE,
           -1);
       if (dynamicTimeoutMin > 0) {
-        options.setDistcpDynamicJobTimeoutMin(1_000L * dynamicTimeoutMin);
+        options.setDistcpDynamicJobTimeoutBase(dynamicTimeoutMin);
       }
       long dynamicTimeoutMax = conf.getLong(
           ConfigurationKeys.COPY_JOB_DYNAMIC_TIMEOUT_MAX,
           -1);
       if (dynamicTimeoutMax > 0) {
-        options.setDistcpDynamicJobTimeoutMax(1_000L * dynamicTimeoutMax);
+        options.setDistcpDynamicJobTimeoutMax(dynamicTimeoutMax);
       }
 
       DistCpWrapper distCpWrapper = new DistCpWrapper(conf);

--- a/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
@@ -74,7 +74,8 @@ public class ConfigurationKeys {
       "airbnb.reair.copy.timeout.dynamic.ms_per_gb_per_mapper";
   public static final String COPY_JOB_DYNAMIC_TIMEOUT_BASE =
       "airbnb.reair.copy.timeout.dynamic.base.ms";
-  public static final String COPY_JOB_DYNAMIC_TIMEOUT_MAX = "airbnb.reair.copy.timeout.dynamic.max.ms";
+  public static final String COPY_JOB_DYNAMIC_TIMEOUT_MAX =
+      "airbnb.reair.copy.timeout.dynamic.max.ms";
   // If a replication job fails, the number of times to retry the job.
   public static final String JOB_RETRIES = "airbnb.reair.job.retries";
   // After a copy, whether to set / check that modified times for the copied files match between

--- a/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
+++ b/main/src/main/java/com/airbnb/reair/incremental/deploy/ConfigurationKeys.java
@@ -70,11 +70,11 @@ public class ConfigurationKeys {
   // Whether to use a size based timeout for copy jobs
   public static final String COPY_JOB_DYNAMIC_TIMEOUT_ENABLED =
       "airbnb.reair.copy.timeout.dynamic.enabled";
-  public static final String COPY_JOB_DYNAMIC_TIMEOUT_SEC_PER_GB =
-      "airbnb.reair.copy.timeout.dynamic.sec_per_gb";
-  public static final String COPY_JOB_DYNAMIC_TIMEOUT_MIN =
-      "airbnb.reair.copy.timeout.dynamic.min";
-  public static final String COPY_JOB_DYNAMIC_TIMEOUT_MAX = "airbnb.reair.copy.timeout.dynamic.max";
+  public static final String COPY_JOB_DYNAMIC_TIMEOUT_MS_PER_GB_PER_MAPPER =
+      "airbnb.reair.copy.timeout.dynamic.ms_per_gb_per_mapper";
+  public static final String COPY_JOB_DYNAMIC_TIMEOUT_BASE =
+      "airbnb.reair.copy.timeout.dynamic.base.ms";
+  public static final String COPY_JOB_DYNAMIC_TIMEOUT_MAX = "airbnb.reair.copy.timeout.dynamic.max.ms";
   // If a replication job fails, the number of times to retry the job.
   public static final String JOB_RETRIES = "airbnb.reair.job.retries";
   // After a copy, whether to set / check that modified times for the copied files match between

--- a/main/src/test/java/test/DistCpWrapperOptionsTest.java
+++ b/main/src/test/java/test/DistCpWrapperOptionsTest.java
@@ -4,20 +4,20 @@ import static org.junit.Assert.assertEquals;
 
 import com.airbnb.reair.common.DistCpWrapperOptions;
 
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.Test;
 
 public class DistCpWrapperOptionsTest {
   @Test
   public void testGetDistCpTimeout() {
     DistCpWrapperOptions distCpWrapperOptions = new DistCpWrapperOptions(null, null, null, null);
     distCpWrapperOptions.setDistCpJobTimeout(1_000L);
-    assertEquals(1_000L, distCpWrapperOptions.getDistcpTimeout(100L));
+    assertEquals(1_000L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(), 100L));
 
     distCpWrapperOptions.setDistcpDynamicJobTimeoutEnabled(false);
-    assertEquals(1_000L, distCpWrapperOptions.getDistcpTimeout(100L));
+    assertEquals(1_000L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(), 100L));
   }
 
   @Test
@@ -25,35 +25,35 @@ public class DistCpWrapperOptionsTest {
     DistCpWrapperOptions distCpWrapperOptions = new DistCpWrapperOptions(null, null, null, null);
 
     List<Long> testCase1 = Arrays.asList(0L, 0L, 0L);
-    long procs1 = 500l;
+    long procs1 = 500L;
     assertEquals(0L, distCpWrapperOptions.computeLongestMapper(testCase1, procs1));
 
     List<Long> testCase2 = Arrays.asList();
-    long procs2 = 2l;
+    long procs2 = 2L;
     assertEquals(0L, distCpWrapperOptions.computeLongestMapper(testCase2, procs2));
 
     List<Long> testCase3 = Arrays.asList();
-    long procs3 = 0l;
+    long procs3 = 0L;
     assertEquals(0L, distCpWrapperOptions.computeLongestMapper(testCase3, procs3));
 
     List<Long> testCase4 = Arrays.asList(100L);
-    long procs4 = 1l;
+    long procs4 = 1L;
     assertEquals(100L, distCpWrapperOptions.computeLongestMapper(testCase4, procs4));
 
     List<Long> testCase5 = Arrays.asList(100L);
-    long procs5 = 2l;
+    long procs5 = 2L;
     assertEquals(100L, distCpWrapperOptions.computeLongestMapper(testCase5, procs5));
 
     List<Long> testCase6 = Arrays.asList(100L, 1L);
-    long procs6 = 2l;
+    long procs6 = 2L;
     assertEquals(100L, distCpWrapperOptions.computeLongestMapper(testCase6, procs6));
 
     List<Long> testCase7 = Arrays.asList(100L, 100L, 100L);
-    long procs7 = 1l;
+    long procs7 = 1L;
     assertEquals(300L, distCpWrapperOptions.computeLongestMapper(testCase7, procs7));
 
     List<Long> testCase8 = Arrays.asList(100L, 50L, 51L);
-    long procs8 = 2l;
+    long procs8 = 2L;
     assertEquals(101L, distCpWrapperOptions.computeLongestMapper(testCase8, procs8));
 
     List<Long> testCase9 = Arrays.asList(100L, 50L, 50L, 50L, 51L);
@@ -82,7 +82,8 @@ public class DistCpWrapperOptionsTest {
     assertEquals(110L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(1_000_000_000L), 2L));
 
     // normal test case
-    assertEquals(120L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(1_000_000_000L, 500_000_000L, 500_000_001L), 2L));
+    assertEquals(120L, distCpWrapperOptions.getDistcpTimeout(
+        Arrays.asList(1_000_000_000L, 500_000_000L, 500_000_001L), 2L));
 
     // test greater than max
     assertEquals(9999L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(Long.MAX_VALUE), 1L));

--- a/main/src/test/java/test/DistCpWrapperOptionsTest.java
+++ b/main/src/test/java/test/DistCpWrapperOptionsTest.java
@@ -4,11 +4,12 @@ import static org.junit.Assert.assertEquals;
 
 import com.airbnb.reair.common.DistCpWrapperOptions;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
 public class DistCpWrapperOptionsTest {
-  private static final long ONE_BILLION = 1_000_000_000L;
-  
   @Test
   public void testGetDistCpTimeout() {
     DistCpWrapperOptions distCpWrapperOptions = new DistCpWrapperOptions(null, null, null, null);
@@ -17,14 +18,73 @@ public class DistCpWrapperOptionsTest {
 
     distCpWrapperOptions.setDistcpDynamicJobTimeoutEnabled(false);
     assertEquals(1_000L, distCpWrapperOptions.getDistcpTimeout(100L));
+  }
 
+  @Test
+  public void testComputeLongestMapper() {
+    DistCpWrapperOptions distCpWrapperOptions = new DistCpWrapperOptions(null, null, null, null);
+
+    List<Long> testCase1 = Arrays.asList(0L, 0L, 0L);
+    long procs1 = 500l;
+    assertEquals(0L, distCpWrapperOptions.computeLongestMapper(testCase1, procs1));
+
+    List<Long> testCase2 = Arrays.asList();
+    long procs2 = 2l;
+    assertEquals(0L, distCpWrapperOptions.computeLongestMapper(testCase2, procs2));
+
+    List<Long> testCase3 = Arrays.asList();
+    long procs3 = 0l;
+    assertEquals(0L, distCpWrapperOptions.computeLongestMapper(testCase3, procs3));
+
+    List<Long> testCase4 = Arrays.asList(100L);
+    long procs4 = 1l;
+    assertEquals(100L, distCpWrapperOptions.computeLongestMapper(testCase4, procs4));
+
+    List<Long> testCase5 = Arrays.asList(100L);
+    long procs5 = 2l;
+    assertEquals(100L, distCpWrapperOptions.computeLongestMapper(testCase5, procs5));
+
+    List<Long> testCase6 = Arrays.asList(100L, 1L);
+    long procs6 = 2l;
+    assertEquals(100L, distCpWrapperOptions.computeLongestMapper(testCase6, procs6));
+
+    List<Long> testCase7 = Arrays.asList(100L, 100L, 100L);
+    long procs7 = 1l;
+    assertEquals(300L, distCpWrapperOptions.computeLongestMapper(testCase7, procs7));
+
+    List<Long> testCase8 = Arrays.asList(100L, 50L, 51L);
+    long procs8 = 2l;
+    assertEquals(101L, distCpWrapperOptions.computeLongestMapper(testCase8, procs8));
+
+    List<Long> testCase9 = Arrays.asList(100L, 50L, 50L, 50L, 51L);
+    long procs9 = 3L;
+    assertEquals(101L, distCpWrapperOptions.computeLongestMapper(testCase9, procs9));
+
+    List<Long> testCase10 = Arrays.asList(100L, 50L, 50L, 50L, 50L);
+    long procs10 = 2L;
+    assertEquals(150L, distCpWrapperOptions.computeLongestMapper(testCase10, procs10));
+  }
+
+  @Test
+  public void testGetDistCpTimeout_Dynamic() {
+    DistCpWrapperOptions distCpWrapperOptions = new DistCpWrapperOptions(null, null, null, null);
     distCpWrapperOptions.setDistcpDynamicJobTimeoutEnabled(true);
-    distCpWrapperOptions.setDistcpDynamicJobTimeoutMin(100);
-    distCpWrapperOptions.setDistcpDynamicJobTimeoutMsPerGb(2);
-    distCpWrapperOptions.setDistcpDynamicJobTimeoutMax(9_999);
+    distCpWrapperOptions.setDistcpDynamicJobTimeoutBase(100L);
+    distCpWrapperOptions.setDistcpDynamicJobTimeoutMax(9999L);
+    distCpWrapperOptions.setDistcpDynamicJobTimeoutMsPerGbPerMapper(10L);
+    // test empty files
+    assertEquals(100L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(0L, 0L), 2L));
 
-    assertEquals(100L, distCpWrapperOptions.getDistcpTimeout(ONE_BILLION * 1L));
-    assertEquals(1_000L, distCpWrapperOptions.getDistcpTimeout(ONE_BILLION * 500L));
-    assertEquals(9_999L, distCpWrapperOptions.getDistcpTimeout(ONE_BILLION * 10_000L));
+    // test no files
+    assertEquals(100L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(), 2L));
+
+    // test 1 file
+    assertEquals(110L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(1_000_000_000L), 2L));
+
+    // normal test case
+    assertEquals(120L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(1_000_000_000L, 500_000_000L, 500_000_001L), 2L));
+
+    // test greater than max
+    assertEquals(9999L, distCpWrapperOptions.getDistcpTimeout(Arrays.asList(Long.MAX_VALUE), 1L));
   }
 }

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapper.java
@@ -102,10 +102,12 @@ public class DistCpWrapper {
 
     Set<FileStatus> fileStatuses =
         FsUtils.getFileStatusesRecursive(conf, srcDir, Optional.empty());
+    List<Long> fileSizes = new ArrayList<>();
 
     long srcSize = 0;
     for (FileStatus status : fileStatuses) {
       srcSize += status.getLen();
+      fileSizes.add(status.getLen());
     }
     LOG.debug(String.format(
         "%s has %s files with a total size of %s bytes",
@@ -169,7 +171,7 @@ public class DistCpWrapper {
       DistCp distCp = new DistCp();
       distCp.setConf(conf);
 
-      long distCpTimeout = options.getDistcpTimeout(srcSize);
+      long distCpTimeout = options.getDistcpTimeout(fileSizes, mappers);
 
       int ret = runDistCp(distCp, distcpArgs, distCpTimeout,
           options.getDistCpPollInterval());

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
@@ -45,7 +45,7 @@ public class DistCpWrapperOptions {
   private boolean distcpDynamicJobTimeoutEnabled = false;
   // timeout in millis per GB per mapper, size will get rounded up
   private long distcpDynamicJobTimeoutMsPerGbPerMapper = 0;
-  // minimum job timeout for variable timeout (ms)
+  // minimum job timeout for variable timeout (ms) which accounts for overhead
   private long distcpDynamicJobTimeoutBase = distcpJobTimeout;
   // maximum job timeout for variable timeout (ms)
   private long distcpDynamicJobTimeoutMax = Long.MAX_VALUE;
@@ -175,11 +175,11 @@ public class DistCpWrapperOptions {
    */
   public long getDistcpTimeout(List<Long> fileSizes, long maxConcurrency) {
     if (distcpDynamicJobTimeoutEnabled) {
-      long bytesPerMapper = computeLongestMapper(fileSizes, maxConcurrency);
+      long bytesPerLongestMapper = computeLongestMapper(fileSizes, maxConcurrency);
       long baseTimeout = distcpDynamicJobTimeoutBase;
       long maxTimeout = distcpDynamicJobTimeoutMax;
       long msPerGb = distcpDynamicJobTimeoutMsPerGbPerMapper;
-      long adjustment = ((long) Math.ceil(bytesPerMapper / 1e9) * msPerGb);
+      long adjustment = ((long) Math.ceil(bytesPerLongestMapper / 1e9) * msPerGb);
       long timeout = Math.min(maxTimeout, baseTimeout + adjustment);
       return timeout;
     } else {

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
@@ -1,5 +1,7 @@
 package com.airbnb.reair.common;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
 
 import java.util.Collections;
@@ -10,6 +12,7 @@ import java.util.PriorityQueue;
  * A class to encapsulate various options required for running DistCp.
  */
 public class DistCpWrapperOptions {
+  private static final Log LOG = LogFactory.getLog(DistCpWrapperOptions.class);
 
   // The source directory to copy
   private Path srcDir;
@@ -181,6 +184,7 @@ public class DistCpWrapperOptions {
       long msPerGb = distcpDynamicJobTimeoutMsPerGbPerMapper;
       long adjustment = ((long) Math.ceil(bytesPerLongestMapper / 1e9) * msPerGb);
       long timeout = Math.min(maxTimeout, baseTimeout + adjustment);
+      LOG.debug(String.format("Setting dynamic timeout of %d milliseconds"));
       return timeout;
     } else {
       return distcpJobTimeout;
@@ -208,6 +212,7 @@ public class DistCpWrapperOptions {
       processors.add(newValue);
       maxValue = Math.max(maxValue, newValue);
     }
+    LOG.debug(String.format("Max mapper has %d bytes", maxValue));
     return maxValue;
   }
 }

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
@@ -184,7 +184,7 @@ public class DistCpWrapperOptions {
       long msPerGb = distcpDynamicJobTimeoutMsPerGbPerMapper;
       long adjustment = ((long) Math.ceil(bytesPerLongestMapper / 1e9) * msPerGb);
       long timeout = Math.min(maxTimeout, baseTimeout + adjustment);
-      LOG.debug(String.format("Setting dynamic timeout of %d milliseconds"));
+      LOG.debug(String.format("Setting dynamic timeout of %d milliseconds", timeout));
       return timeout;
     } else {
       return distcpJobTimeout;

--- a/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
+++ b/utils/src/main/java/com/airbnb/reair/common/DistCpWrapperOptions.java
@@ -184,7 +184,8 @@ public class DistCpWrapperOptions {
       long msPerGb = distcpDynamicJobTimeoutMsPerGbPerMapper;
       long adjustment = ((long) Math.ceil(bytesPerLongestMapper / 1e9) * msPerGb);
       long timeout = Math.min(maxTimeout, baseTimeout + adjustment);
-      LOG.debug(String.format("Setting dynamic timeout of %d milliseconds", timeout));
+      LOG.debug(String.format("Setting dynamic timeout of %d milliseconds for max mapper size %d",
+          timeout, bytesPerLongestMapper));
       return timeout;
     } else {
       return distcpJobTimeout;
@@ -212,7 +213,6 @@ public class DistCpWrapperOptions {
       processors.add(newValue);
       maxValue = Math.max(maxValue, newValue);
     }
-    LOG.debug(String.format("Max mapper has %d bytes", maxValue));
     return maxValue;
   }
 }


### PR DESCRIPTION
This changes the dynamic timeout method to be calculated as
(filesize * CONSTANT) sandwiched between MIN and MAX 
to
(estimated_bytes_per_busiest_mapper * CONSTANT) + BASE, subject to a MAX

This should more accurately represent DistCp jobs since some jobs are skewed toward large files.

@plypaul 