### PR TITLE
Set Worker name to include job string name

### DIFF
--- a/utils/src/main/java/com/airbnb/reair/multiprocessing/Worker.java
+++ b/utils/src/main/java/com/airbnb/reair/multiprocessing/Worker.java
@@ -1,10 +1,10 @@
 package com.airbnb.reair.multiprocessing;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Executes a job in a thread. The job is required to return a return code of 0 or else an exception


### PR DESCRIPTION
This PR adds the job name to the worker name to provide more context when looking at logs, allowing to grep all output for a given job id.

PTAL @plypaul 